### PR TITLE
Do more work in the background to avoid blocking the UI

### DIFF
--- a/DolphinBisectTool/Backend.cs
+++ b/DolphinBisectTool/Backend.cs
@@ -94,8 +94,22 @@ namespace DolphinBisectTool
         public void DownloadBuildList()
         {
             using (WebClient client = new WebClient())
-                client.DownloadFile(new Uri("https://dl.dolphin-emu.org/builds/"),
+            using (var download_finished = new ManualResetEvent(false))
+            {
+                client.DownloadProgressChanged += (s, e) =>
+                {
+                    m_form.ChangeProgressBar(e.ProgressPercentage, "Downloading build index");
+                };
+
+                client.DownloadFileCompleted += (s, e) =>
+                {
+                    download_finished.Set();
+                };
+
+                client.DownloadFileAsync(new Uri("https://dl.dolphin-emu.org/builds/"),
                          "buildindex");
+                download_finished.WaitOne();
+            }
         }
 
         public void ProcessBuildList()

--- a/DolphinBisectTool/Backend.cs
+++ b/DolphinBisectTool/Backend.cs
@@ -152,8 +152,8 @@ namespace DolphinBisectTool
             {
                 client.DownloadProgressChanged += (s, e) =>
                 {
-                    m_form.ChangeProgressBar(e.ProgressPercentage, "Downloading build " +
-                                             m_build_list.ElementAt(index));
+                    m_form.ChangeProgressBar(e.ProgressPercentage,
+                        string.Format("Downloading build {0}-{1}", s_major_version, m_build_list[index]));
                 };
 
                 client.DownloadFileCompleted += (s, e) =>

--- a/DolphinBisectTool/Backend.cs
+++ b/DolphinBisectTool/Backend.cs
@@ -159,8 +159,8 @@ namespace DolphinBisectTool
                 {
                     // Known Bug: Sometimes the label doesn't get updated before it extracts and
                     // launches. I want to blame this meh-level 7z lib blocking something.
-                    m_form.ChangeProgressBar(-1, "Extracting and launching");
                     SevenZipExtractor dolphin_zip = new SevenZipExtractor(@"dolphin.7z");
+                    dolphin_zip.Extracting += (sender, eventArgs) => m_form.ChangeProgressBar(eventArgs.PercentDone, "Extracting and launching");
                     dolphin_zip.ExtractArchive("dolphin");
                     download_finished.Set();
                 };

--- a/DolphinBisectTool/Backend.cs
+++ b/DolphinBisectTool/Backend.cs
@@ -19,10 +19,11 @@ namespace DolphinBisectTool
         // Follow this format: (Major).0
         public static string s_major_version = "4.0";
         public List<int> m_build_list = new List<int>();
-        MainWindow m_form;
+        private readonly MainWindow m_form;
 
-        public Backend()
+        public Backend(MainWindow form)
         {
+            m_form = form;
             // TODO - Replace this lib with SharpCompress
             SevenZipBase.SetLibraryPath(@"7z.dll");
         }
@@ -77,19 +78,17 @@ namespace DolphinBisectTool
             m_title = "";
         }
 
-        public void SetSettings(int first, int second, MainWindow f)
+        public void SetSettings(int first, int second)
         {
             m_min = first;
             m_max = second;
-            m_form = f;
         }
 
-        public void SetSettings(int first, int second, string path, MainWindow f)
+        public void SetSettings(int first, int second, string path)
         {
             m_min = first;
             m_max = second;
             m_title = path;
-            m_form = f;
         }
 
         public void DownloadBuildList()

--- a/DolphinBisectTool/Backend.cs
+++ b/DolphinBisectTool/Backend.cs
@@ -98,7 +98,7 @@ namespace DolphinBisectTool
             {
                 client.DownloadProgressChanged += (s, e) =>
                 {
-                    m_form.ChangeProgressBar(e.ProgressPercentage, "Downloading build index");
+                    m_form.ChangeProgressBar(e.TotalBytesToReceive > 0 ? e.ProgressPercentage : -1, "Downloading build index");
                 };
 
                 client.DownloadFileCompleted += (s, e) =>
@@ -160,7 +160,7 @@ namespace DolphinBisectTool
                 {
                     // Known Bug: Sometimes the label doesn't get updated before it extracts and
                     // launches. I want to blame this meh-level 7z lib blocking something.
-                    m_form.ChangeProgressBar(0, "Extracting and launching");
+                    m_form.ChangeProgressBar(-1, "Extracting and launching");
                     SevenZipExtractor dolphin_zip = new SevenZipExtractor(@"dolphin.7z");
                     dolphin_zip.ExtractArchive("dolphin");
                     download_finished.Set();

--- a/DolphinBisectTool/Backend.cs
+++ b/DolphinBisectTool/Backend.cs
@@ -1,13 +1,12 @@
-﻿using SevenZip;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
-using System.Windows.Forms;
 using System.Threading;
+using System.Windows.Forms;
+using SevenZip;
 
 namespace DolphinBisectTool
 {
@@ -43,12 +42,12 @@ namespace DolphinBisectTool
                 else
                     index = (m_min + m_max) / 2;
 
-                DownloadBuild(base_url + "-" + m_build_list.ElementAt(index) +
+                DownloadBuild(base_url + "-" + m_build_list[index] +
                               "-x64.7z", index);
                 RunBuild();
 
                 DialogResult dialog_result = MessageBox.Show("Testing build " +
-                             m_build_list.ElementAt(index) + ". Does the issue appear?",
+                             s_major_version + "-" + m_build_list[index] + ". Did the issue appear?",
                              "Notice", MessageBoxButtons.YesNoCancel);
 
                 if (dialog_result == DialogResult.Yes)
@@ -66,7 +65,7 @@ namespace DolphinBisectTool
                 }
             }
 
-            int broken_build = (m_build_list.ElementAt(index) + 1);
+            int broken_build = (m_build_list[index] + 1);
             DialogResult show_build_page =
                          MessageBox.Show("Build " + s_major_version + "-" + broken_build +
                                          " may be the cause of your issue. " +
@@ -178,8 +177,8 @@ namespace DolphinBisectTool
                 runner.StartInfo.WorkingDirectory = Directory.GetCurrentDirectory() +
                                                     @"\dolphin\Dolphin-x64\";
                 runner.StartInfo.FileName = "Dolphin.exe";
-                if (!m_title.Equals(""))
-                    runner.StartInfo.Arguments = "/b /e " + "\"" + m_title + "\"";
+                if (!string.IsNullOrEmpty(m_title))
+                    runner.StartInfo.Arguments = string.Format("/b /e \"{0}\"", m_title);
                 runner.Start();
                 runner.WaitForExit();
             }

--- a/DolphinBisectTool/DolphinBisectTool.csproj
+++ b/DolphinBisectTool/DolphinBisectTool.csproj
@@ -16,7 +16,7 @@
     </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -26,7 +26,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>

--- a/DolphinBisectTool/MainWindow.cs
+++ b/DolphinBisectTool/MainWindow.cs
@@ -96,8 +96,10 @@ namespace DolphinBisectTool
                                     second_dev_build.SelectedIndex, this);
             }
 
+            start_button.Enabled = false;
             var testWorker = new BackgroundWorker();
             testWorker.DoWork += (s, ea) => m_backend.Run();
+            testWorker.RunWorkerCompleted += (s, ea) => start_button.Enabled = true;
             testWorker.RunWorkerAsync();
         }
         

--- a/DolphinBisectTool/MainWindow.cs
+++ b/DolphinBisectTool/MainWindow.cs
@@ -80,29 +80,36 @@ namespace DolphinBisectTool
             {
                 m_backend.SetSettings(-1, second_dev_build.SelectedIndex, file_path_textbox.Text,
                                       this);
-                m_backend.Run();
             }
             else if (radio_stable.Checked)
             {
                 m_backend.SetSettings(-1, second_dev_build.SelectedIndex, this);
-                m_backend.Run();
             }
             else if (!radio_stable.Checked && boot_title.Checked)
             {
                 m_backend.SetSettings(first_dev_build.SelectedIndex,
                                     second_dev_build.SelectedIndex, file_path_textbox.Text, this);
-                m_backend.Run();
             }
             else
             {
                 m_backend.SetSettings(first_dev_build.SelectedIndex,
                                     second_dev_build.SelectedIndex, this);
-                m_backend.Run();
             }
+
+            var testWorker = new BackgroundWorker();
+            testWorker.DoWork += (s, ea) => m_backend.Run();
+            testWorker.RunWorkerAsync();
         }
         
         public void ChangeProgressBar(int v, string t)
         {
+            // pass the call to the UI thread if necessary
+            if (InvokeRequired)
+            {
+                Invoke(new Action<int, string>(ChangeProgressBar), v, t);
+                return;
+            }
+
             if (v != 100)
             {
                 download_bar.Visible = true;

--- a/DolphinBisectTool/MainWindow.cs
+++ b/DolphinBisectTool/MainWindow.cs
@@ -7,13 +7,14 @@ namespace DolphinBisectTool
 {
     public partial class MainWindow : Form
     {
-        Backend m_backend = new Backend();
+        private readonly Backend m_backend;
 
         public MainWindow()
         {
             InitializeComponent();
             FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
 
+            m_backend = new Backend(this);
             download_label.Text = "Downloading build index";
             download_label.Visible = true;
 
@@ -78,22 +79,21 @@ namespace DolphinBisectTool
 
             if (radio_stable.Checked && boot_title.Checked)
             {
-                m_backend.SetSettings(-1, second_dev_build.SelectedIndex, file_path_textbox.Text,
-                                      this);
+                m_backend.SetSettings(-1, second_dev_build.SelectedIndex, file_path_textbox.Text);
             }
             else if (radio_stable.Checked)
             {
-                m_backend.SetSettings(-1, second_dev_build.SelectedIndex, this);
+                m_backend.SetSettings(-1, second_dev_build.SelectedIndex);
             }
             else if (!radio_stable.Checked && boot_title.Checked)
             {
                 m_backend.SetSettings(first_dev_build.SelectedIndex,
-                                    second_dev_build.SelectedIndex, file_path_textbox.Text, this);
+                    second_dev_build.SelectedIndex, file_path_textbox.Text);
             }
             else
             {
                 m_backend.SetSettings(first_dev_build.SelectedIndex,
-                                    second_dev_build.SelectedIndex, this);
+                    second_dev_build.SelectedIndex);
             }
 
             start_button.Enabled = false;

--- a/DolphinBisectTool/MainWindow.cs
+++ b/DolphinBisectTool/MainWindow.cs
@@ -12,7 +12,7 @@ namespace DolphinBisectTool
         public MainWindow()
         {
             InitializeComponent();
-            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            FormBorderStyle = FormBorderStyle.FixedSingle;
 
             m_backend = new Backend(this);
             download_label.Text = "Downloading build index";
@@ -66,7 +66,7 @@ namespace DolphinBisectTool
                 return;
             }
 
-            if (boot_title.Checked && file_path_textbox.Text.Equals(""))
+            if (boot_title.Checked && string.IsNullOrEmpty(file_path_textbox.Text))
             {
                 MessageBox.Show("Boot title enabled with no game / title selected",
                                 "Error", MessageBoxButtons.OK);

--- a/DolphinBisectTool/MainWindow.cs
+++ b/DolphinBisectTool/MainWindow.cs
@@ -117,7 +117,17 @@ namespace DolphinBisectTool
                 download_bar.Visible = true;
                 download_label.Text = t;
                 download_label.Visible = true;
-                download_bar.Value = v;
+
+                // accept -1 as indicator that we don't know the progress
+                if (v == -1)
+                {
+                    download_bar.Style = ProgressBarStyle.Marquee;
+                }
+                else
+                {
+                    download_bar.Style = ProgressBarStyle.Continuous;
+                    download_bar.Value = v;
+                }
             }
             else
             {


### PR DESCRIPTION
We already talked about this on IRC, and it might be a good idea to split the Backend into (at least) 3 distinct classes with each their own application/use.

But until this happens, some improvements of the code itself. `Backend.Run` is now put into the background using a `BackgroundWorker`, which makes it less problematic wrt blocking the UI and leaving the user with the impression that the application is hung, stuck or otherwise dying.

Along with this, I also added a few download-related things - all of them now use the `WebClient.DownloadFileAsync` method, which allows us to get some progress. Unfortunately, the build index does not include a total file size, so we cannot really do anything else but let the progress bar run a Marquee effect (just to indicate "we're still here and working").

Even though you want to replace the 7z Library with something less crappy, I hooked up the progress even regardless. It's not as accurate as I thought, but again, it's showing the user that we're still here.
And until then, I also changed the Platform Target of the Project to be x86 - otherwise the 32-bit 7z.dll won't load correctly.

Along with that, I did some other cleanups (mostly best practise related; such as the `string.IsNullOrEmpty` and `readonly` changes), made the response messages more consistent (by always including the base/stable version number in the known format) and moved the main form right into the constructor of Backend. In the long run, it should be removed from Backend completely, but until that happens its better to have it in there (since we can be sure that a reference is there at all times).
