### PR TITLE
Update runner arguments to support Dolphin's new arguments style

### DIFF
--- a/DolphinBisectTool/RunBuild.cs
+++ b/DolphinBisectTool/RunBuild.cs
@@ -21,7 +21,7 @@ namespace DolphinBisectTool
                 runner.StartInfo.FileName = starting_directory + string.Join("", match);
                 runner.StartInfo.UseShellExecute = false;
                 if (!string.IsNullOrEmpty(title))
-                    runner.StartInfo.Arguments = string.Format("/b /e \"{0}\"", title);
+                    runner.StartInfo.Arguments = string.Format("-b -e \"{0}\"", title);
                 runner.Start();
                 runner.WaitForExit();
             }


### PR DESCRIPTION
/b /e is now -b -e
Still works in older builds, works again in newer builds.