### PR TITLE
BuildList: Fix downloading builds with new download url [Do not merge]

### DIFF
--- a/DolphinBisectTool/MainWindow.cs
+++ b/DolphinBisectTool/MainWindow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace DolphinBisectTool
@@ -7,7 +8,7 @@ namespace DolphinBisectTool
     public partial class MainWindow : Form
     {
 
-        List<string> m_build_list;
+        Dictionary<string, string> m_build_list;
         static string s_major_version = "5.0";
 
         DownloadBuildList m_download_build_list = new DownloadBuildList();
@@ -30,12 +31,12 @@ namespace DolphinBisectTool
             DialogResult result;
             if (!final_trigger)
             {
-                result = MessageBox.Show("Tested build " + m_build_list[build] + ". Did the bug happen in this build?",
+                result = MessageBox.Show("Tested build " + m_build_list.ElementAt(build).Key + ". Did the bug happen in this build?",
                          "Bisect", MessageBoxButtons.YesNoCancel);
             }
             else
             {
-                result = MessageBox.Show("Build " + m_build_list[build-1] + " may be the cause of your issue. " +
+                result = MessageBox.Show("Build " + m_build_list.ElementAt(build-1).Key + " may be the cause of your issue. " +
                                          "Do you want to open the URL for that build?", "Notice",
                                          MessageBoxButtons.YesNo);
                 start_button.Enabled = true;
@@ -111,8 +112,8 @@ namespace DolphinBisectTool
                 download_label.Text = text;
                 download_bar.Style = style;
                 ProcessBuildList process_build = new ProcessBuildList();
-                m_build_list = process_build.Run(s_major_version);
-                PopulateComboBoxes(m_build_list);
+                m_build_list = process_build.Run();
+                PopulateComboBoxes(m_build_list.Keys.ToList());
             }
             else
             {

--- a/DolphinBisectTool/ProcessBuildList.cs
+++ b/DolphinBisectTool/ProcessBuildList.cs
@@ -7,14 +7,28 @@ namespace DolphinBisectTool
 {
     class ProcessBuildList
     {
-        public List<string> Run(string s_major_version)
+        public Dictionary<string, string> Run()
         {
             using (StreamReader reader = new StreamReader("buildindex"))
             {
                 string raw_data = reader.ReadLine();
                 string refined_data = raw_data.Replace("\"", "").Replace("[", "").Replace("]", "").Replace(" ", "");
 
-                List<string> result = refined_data.Split(',').ToList();
+                Dictionary<string, string> result = new Dictionary<string, string>();
+                string[] items = refined_data.Split(',');
+
+                for (int i = 0; i < items.Length; i += 2)
+                {
+                    // A key without a value *should* be impossible, however this prevents a crash.
+                    if (i + 2 > items.Length)
+                        continue;
+
+                    if (result.ContainsKey(items[i]))
+                        continue; // There are two version 4.0-390s. 
+
+                    result.Add(items[i], items[i + 1]);
+                }
+
                 return result;
             }
         }


### PR DESCRIPTION
This PR revives the DolphinBisectTool by utilising the URLs that will be supplied in the buildlist if this open [pull request to add download URLs with the revisions in the build list](https://github.com/dolphin-emu/www/pull/123) is merged.

This cannot be fully tested unless that PR is merged. However the testing that I could do suggests this works. I have opened this pull request in preparation and so that any reviews may be made. This may be followed with another commit to fix or adjust any behaviour if needed.